### PR TITLE
Fix schema validation errors in BiotrialResting1020

### DIFF
--- a/tasks/resting/BiotrialResting1020.py
+++ b/tasks/resting/BiotrialResting1020.py
@@ -40,7 +40,7 @@ config = {
         'enabled': True,
         'value': {
             'eog_indices': [31, 32],
-            'eog_drop': None
+            'eog_drop': True
         }
     },
     'trim_step': {

--- a/tasks/resting/BiotrialResting1020.py
+++ b/tasks/resting/BiotrialResting1020.py
@@ -19,7 +19,6 @@ from autoclean.core.task import Task
 # =============================================================================
 
 config = {
-'dataset_name': "BiotrialResting1020",
     'resample_step': {
         'enabled': True,
         'value': 256
@@ -39,7 +38,10 @@ config = {
     },
     'eog_step': {
         'enabled': True,
-        'value': [31, 32]
+        'value': {
+            'eog_indices': [31, 32],
+            'eog_drop': None
+        }
     },
     'trim_step': {
         'enabled': True,
@@ -74,6 +76,7 @@ config = {
     },
     'component_rejection': {
         'enabled': True,
+        'method': 'iclabel',
         'value': {
             'ic_flags_to_reject': ['muscle', 'heart', 'eog', 'ch_noise', 'line_noise'],
             'ic_rejection_threshold': 0.3,


### PR DESCRIPTION
Fixes schema validation errors in BiotrialResting1020.py

- Fixed eog_step.value to be dict with eog_indices and eog_drop keys
- Added missing method key to component_rejection (set to 'iclabel')
- Removed dataset_name key which is not in schema

Closes #2

Generated with [Claude Code](https://claude.ai/code)