### PR TITLE
feat: add Mouse_ASSR_40Hz and Mouse_ASSR_80Hz task files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ See **[Task Catalog](https://cincibrainlab.github.io/autocleaneeg-task-registry/
 - **Mouse_XDAT_ASSR** - Mouse ASSR with correlation-based artifact rejection
 - **Mouse_XDAT_Chirp** - Mouse chirp with correlation-based artifact rejection
 - **Mouse_XDAT_Resting** - Mouse resting-state with correlation-based artifact rejection
+- **Mouse_ASSR_40Hz** - Mouse 40Hz ASSR with TTL pulse event detection (MEA30 montage)
+- **Mouse_ASSR_80Hz** - Mouse 80Hz ASSR with TTL pulse event detection (MEA30 montage)
 
 ## Task Schema Version
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -18,6 +18,8 @@ Comprehensive directory of validated AutoClean EEG tasks organized by paradigm c
 | **Mouse_XDAT_ASSR** | Rodent | MEA30 | Mouse ASSR | No | Event (1.0s) |
 | **Mouse_XDAT_Chirp** | Rodent | MEA30 | Mouse chirp | No | Event (1.0s) |
 | **Mouse_XDAT_Resting** | Rodent | MEA30 | Mouse resting-state | No | Regular (2s) |
+| **Mouse_ASSR_40Hz** | Rodent | MEA30 | Mouse 40Hz ASSR | No | Event (1.0s) |
+| **Mouse_ASSR_80Hz** | Rodent | MEA30 | Mouse 80Hz ASSR | No | Event (1.0s) |
 
 ## Categories
 
@@ -131,6 +133,24 @@ Comprehensive directory of validated AutoClean EEG tasks organized by paradigm c
 - **ICA**: Disabled (uses correlation-based channel rejection)
 - **Epochs**: 2-second non-overlapping regular epochs
 - **Use Case**: Preclinical baseline neural activity
+
+**Mouse_ASSR_40Hz**
+- **Purpose**: Mouse 40Hz ASSR with TTL pulse event detection
+- **Montage**: MEA30 (30-channel microelectrode array)
+- **Filtering**: 1-100 Hz, notch 60/120 Hz
+- **ICA**: Disabled (optimized for rodent recordings)
+- **Epochs**: -0.2 to 0.8s around stimulus onset
+- **Event ID**: `assr_40hz: 1`
+- **Use Case**: Preclinical 40Hz auditory steady-state response studies
+
+**Mouse_ASSR_80Hz**
+- **Purpose**: Mouse 80Hz ASSR with TTL pulse event detection
+- **Montage**: MEA30 (30-channel microelectrode array)
+- **Filtering**: 1-100 Hz, notch 60/120 Hz
+- **ICA**: Disabled (optimized for rodent recordings)
+- **Epochs**: -0.2 to 0.8s around stimulus onset
+- **Event ID**: `assr_80hz: 1`
+- **Use Case**: Preclinical 80Hz auditory steady-state response studies
 
 ## Common Parameters
 

--- a/registry.json
+++ b/registry.json
@@ -115,6 +115,18 @@
       "path": "tasks/rodent/Mouse_XDAT_Resting.py",
       "category": "rodent",
       "description": "Mouse resting-state with correlation-based artifact rejection"
+    },
+    {
+      "name": "Mouse_ASSR_40Hz",
+      "path": "tasks/rodent/Mouse_ASSR_40Hz.py",
+      "category": "rodent",
+      "description": "Mouse 40Hz ASSR with TTL pulse event detection (MEA30 montage)"
+    },
+    {
+      "name": "Mouse_ASSR_80Hz",
+      "path": "tasks/rodent/Mouse_ASSR_80Hz.py",
+      "category": "rodent",
+      "description": "Mouse 80Hz ASSR with TTL pulse event detection (MEA30 montage)"
     }
   ]
 }

--- a/tasks/rodent/Mouse_ASSR_40Hz.py
+++ b/tasks/rodent/Mouse_ASSR_40Hz.py
@@ -1,0 +1,95 @@
+"""Mouse ASSR 40Hz task with TTL pulses.
+
+This task implements the 40Hz ASSR (Auditory Steady-State Response) protocol
+for mouse recordings using MEA30 electrode arrays with TTL pulse-based event
+detection optimized for preclinical studies.
+"""
+
+from __future__ import annotations
+
+from autoclean.core.task import Task
+
+config = {
+    "schema_version": "2025.09",
+    "montage": {"enabled": True, "value": "MEA30"},
+    "move_flagged_files": False,
+    "resample_step": {"enabled": True, "value": 500},
+    "filtering": {
+        "enabled": True,
+        "value": {"l_freq": 1.0, "h_freq": 100.0, "notch_freqs": [60, 120]},
+    },
+    "drop_outerlayer": {"enabled": False, "value": []},
+    "eog_step": {
+        "enabled": False,
+        "value": {
+            "eog_indices": [],
+            "eog_drop": False,
+        },
+    },
+    "trim_step": {"enabled": True, "value": 2},
+    "crop_step": {"enabled": False, "value": {"start": 0, "end": 0}},
+    "reference_step": {"enabled": False, "value": "average"},
+    "ICA": {
+        "enabled": False,
+        "value": {
+            "method": "fastica",
+            "n_components": None,
+            "fit_params": {"tol": 0.0001},
+            "temp_highpass_for_ica": 1.0,
+        },
+    },
+    "component_rejection": {
+        "enabled": False,
+        "method": "iclabel",
+        "value": {
+            "ic_flags_to_reject": [
+                "muscle",
+                "heart",
+                "eog",
+                "ch_noise",
+                "line_noise",
+            ],
+            "ic_rejection_threshold": 0.3,
+            "psd_fmax": 100.0,
+        },
+    },
+    "epoch_settings": {
+        "enabled": True,
+        "value": {"tmin": -0.2, "tmax": 0.8},
+        "event_id": {"assr_40hz": 1},
+        "remove_baseline": {"enabled": True, "window": [-0.2, 0.0]},
+        "threshold_rejection": {
+            "enabled": False,
+            "volt_threshold": {"eeg": 0.000125},
+        },
+    },
+    "ai_reporting": False,
+}
+
+
+class Mouse_ASSR_40Hz(Task):
+    """Task for mouse 40Hz ASSR recordings with TTL pulse event detection."""
+
+    def run(self) -> None:
+        self.import_raw()
+        self.resample_data()
+        self.filter_data()
+        self.drop_outer_layer()
+        self.assign_eog_channels()
+        self.trim_edges()
+        self.crop_duration()
+
+        self.original_raw = self.raw.copy()
+
+        self.clean_bad_channels()
+        self.raw.interpolate_bads(reset_bads=False)
+
+        self.create_eventid_epochs()
+
+        self.generate_reports()
+
+    def generate_reports(self) -> None:
+        if self.raw is None:
+            return
+
+        self.verify_topography_plot()

--- a/tasks/rodent/Mouse_ASSR_80Hz.py
+++ b/tasks/rodent/Mouse_ASSR_80Hz.py
@@ -1,0 +1,95 @@
+"""Mouse ASSR 80Hz task with TTL pulses.
+
+This task implements the 80Hz ASSR (Auditory Steady-State Response) protocol
+for mouse recordings using MEA30 electrode arrays with TTL pulse-based event
+detection optimized for preclinical studies.
+"""
+
+from __future__ import annotations
+
+from autoclean.core.task import Task
+
+config = {
+    "schema_version": "2025.09",
+    "montage": {"enabled": True, "value": "MEA30"},
+    "move_flagged_files": False,
+    "resample_step": {"enabled": True, "value": 500},
+    "filtering": {
+        "enabled": True,
+        "value": {"l_freq": 1.0, "h_freq": 100.0, "notch_freqs": [60, 120]},
+    },
+    "drop_outerlayer": {"enabled": False, "value": []},
+    "eog_step": {
+        "enabled": False,
+        "value": {
+            "eog_indices": [],
+            "eog_drop": False,
+        },
+    },
+    "trim_step": {"enabled": True, "value": 2},
+    "crop_step": {"enabled": False, "value": {"start": 0, "end": 0}},
+    "reference_step": {"enabled": False, "value": "average"},
+    "ICA": {
+        "enabled": False,
+        "value": {
+            "method": "fastica",
+            "n_components": None,
+            "fit_params": {"tol": 0.0001},
+            "temp_highpass_for_ica": 1.0,
+        },
+    },
+    "component_rejection": {
+        "enabled": False,
+        "method": "iclabel",
+        "value": {
+            "ic_flags_to_reject": [
+                "muscle",
+                "heart",
+                "eog",
+                "ch_noise",
+                "line_noise",
+            ],
+            "ic_rejection_threshold": 0.3,
+            "psd_fmax": 100.0,
+        },
+    },
+    "epoch_settings": {
+        "enabled": True,
+        "value": {"tmin": -0.2, "tmax": 0.8},
+        "event_id": {"assr_80hz": 1},
+        "remove_baseline": {"enabled": True, "window": [-0.2, 0.0]},
+        "threshold_rejection": {
+            "enabled": False,
+            "volt_threshold": {"eeg": 0.000125},
+        },
+    },
+    "ai_reporting": False,
+}
+
+
+class Mouse_ASSR_80Hz(Task):
+    """Task for mouse 80Hz ASSR recordings with TTL pulse event detection."""
+
+    def run(self) -> None:
+        self.import_raw()
+        self.resample_data()
+        self.filter_data()
+        self.drop_outer_layer()
+        self.assign_eog_channels()
+        self.trim_edges()
+        self.crop_duration()
+
+        self.original_raw = self.raw.copy()
+
+        self.clean_bad_channels()
+        self.raw.interpolate_bads(reset_bads=False)
+
+        self.create_eventid_epochs()
+
+        self.generate_reports()
+
+    def generate_reports(self) -> None:
+        if self.raw is None:
+            return
+
+        self.verify_topography_plot()


### PR DESCRIPTION
Add two new rodent task files for mouse EEG analysis:
- Mouse_ASSR_40Hz: 40Hz ASSR task with TTL pulse event detection
- Mouse_ASSR_80Hz: 80Hz ASSR task with TTL pulse event detection

Both tasks use MEA30 montage and follow the v2025.09 schema.
Updated registry.json and documentation to include the new tasks.

Closes #4

Generated with [Claude Code](https://claude.ai/code)